### PR TITLE
NEAR contract: fix `init_transfer()` balance validation

### DIFF
--- a/near/contracts/bridge/src/lib.rs
+++ b/near/contracts/bridge/src/lib.rs
@@ -1024,7 +1024,11 @@ mod tests {
         let transfer_account: AccountId = AccountId::try_from("bob_near".to_string()).unwrap();
         let transfer_token_amount = 150;
 
-        contract.ft_on_transfer(transfer_account.clone(), U128(transfer_token_amount), "".to_string());
+        contract.ft_on_transfer(
+            transfer_account.clone(),
+            U128(transfer_token_amount),
+            "".to_string(),
+        );
 
         let user_balance = contract.user_balances.get(&transfer_account).unwrap();
         let user_balance_for_transfer_token = user_balance.get(&transfer_token).unwrap();


### PR DESCRIPTION
If the `transfer_message.transfer.token_near` is the same as `transfer_message.fee.token` then the balance validation is not correct because it doesn't check the sum of them. To fix this issue we need to decrease the balance before the next check.