### PR TITLE
NEAR: fix balance increase, fix emitting deposit event

### DIFF
--- a/near/contracts/bridge/src/ft.rs
+++ b/near/contracts/bridge/src/ft.rs
@@ -33,7 +33,14 @@ impl FungibleTokenReceiver for SpectreBridge {
             self.init_transfer_internal(transfer_message, sender_id, Some(update_balance))
                 .into()
         } else {
-            self.update_balance(sender_id, token_account_id, amount.0);
+            self.increase_balance(&sender_id, &token_account_id, &amount.0);
+
+            Event::SpectreBridgeDepositEvent {
+                sender_id,
+                token: token_account_id,
+                amount,
+            }
+            .emit();
             PromiseOrValue::Value(U128::from(0))
         }
     }


### PR DESCRIPTION
* Fix crash on balance increase call for a new account.
* Fix deposited event emits: deposited event should no longer be emitted if the `init_transfer_callback()` receipt fails.