### PR TITLE
Ethereum: disable generating metadata on compilation

### DIFF
--- a/eth/hardhat.config.js
+++ b/eth/hardhat.config.js
@@ -88,4 +88,5 @@ module.exports = {
 if (process.env.FORKING_BLOCK_NUMBER)
     module.exports.networks.hardhat.forking.blockNumber = +process.env.FORKING_BLOCK_NUMBER;
 
-if (process.env.HARDFORK) module.exports.networks.hardhat.hardfork = process.env.HARDFORK;
+if (process.env.HARDFORK)
+    module.exports.networks.hardhat.hardfork = process.env.HARDFORK;


### PR DESCRIPTION
Do not include the metadata hash, since this is machine dependent and we want all generated code to be deterministic