### PR TITLE
Whitelist: add code comments

### DIFF
--- a/near/contracts/bridge/src/whitelist.rs
+++ b/near/contracts/bridge/src/whitelist.rs
@@ -71,7 +71,7 @@ impl FastBridge {
                     ),
                 );
             }
-            // No action needed for CheckToken, as the token is already checked in whitelist_tokens
+            // No action is needed for CheckToken, as the token is already checked in whitelist_tokens
             WhitelistMode::CheckToken => {}
             WhitelistMode::Blocked => {
                 env::panic_str(format!("The token `{}` is blocked", token).as_str())


### PR DESCRIPTION
In the `check_whitelist_token_and_account` function, the `CheckToken` variant of the `WhitelistMode` enum has an empty block, which might be unclear to readers of the code. This variant is intended to indicate that only the token needs to be checked against the whitelist, and no action is required for the associated account. However, the current implementation with an empty block might not effectively communicate this intent. To mitigate this, a comment for the `CheckToken` invariant is added to the code.

