### PR TITLE
Add admin api to force increase the user's balance

### DIFF
--- a/aurora/.openzeppelin/unknown-1313161554.json
+++ b/aurora/.openzeppelin/unknown-1313161554.json
@@ -555,6 +555,284 @@
           }
         }
       }
+    },
+    "26691265c2c27ba4f0715abb3248e162eda1ba1e82003809ea3a3363378f3982": {
+      "address": "0x5786312ADa306b7693Dc6Da5066258b04183FC5c",
+      "txHash": "0x1282ef832271674a282738c73dad8cb0b9085ef2e4d33630067c9bac421ec0c1",
+      "layout": {
+        "solcVersion": "0.8.17",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC1967UpgradeUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:169"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:111"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)1837_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:62"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:260"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "near",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_struct(NEAR)29_storage",
+            "contract": "AuroraErc20FastBridge",
+            "src": "contracts/src/AuroraErc20FastBridge.sol:43"
+          },
+          {
+            "label": "fastBridgeAccountIdOnNear",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_string_storage",
+            "contract": "AuroraErc20FastBridge",
+            "src": "contracts/src/AuroraErc20FastBridge.sol:44"
+          },
+          {
+            "label": "auroraEngineAccountIdOnNear",
+            "offset": 0,
+            "slot": "303",
+            "type": "t_string_storage",
+            "contract": "AuroraErc20FastBridge",
+            "src": "contracts/src/AuroraErc20FastBridge.sol:45"
+          },
+          {
+            "label": "isWhitelistModeEnabled",
+            "offset": 0,
+            "slot": "304",
+            "type": "t_bool",
+            "contract": "AuroraErc20FastBridge",
+            "src": "contracts/src/AuroraErc20FastBridge.sol:46"
+          },
+          {
+            "label": "whitelistedUsers",
+            "offset": 0,
+            "slot": "305",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "AuroraErc20FastBridge",
+            "src": "contracts/src/AuroraErc20FastBridge.sol:49"
+          },
+          {
+            "label": "registeredTokens",
+            "offset": 0,
+            "slot": "306",
+            "type": "t_mapping(t_string_memory_ptr,t_struct(TokenInfo)6731_storage)",
+            "contract": "AuroraErc20FastBridge",
+            "src": "contracts/src/AuroraErc20FastBridge.sol:53"
+          },
+          {
+            "label": "balance",
+            "offset": 0,
+            "slot": "307",
+            "type": "t_mapping(t_string_memory_ptr,t_mapping(t_address,t_uint128))",
+            "contract": "AuroraErc20FastBridge",
+            "src": "contracts/src/AuroraErc20FastBridge.sol:57"
+          },
+          {
+            "label": "nativeTokenAccountIdOnNear",
+            "offset": 0,
+            "slot": "308",
+            "type": "t_string_storage",
+            "contract": "AuroraErc20FastBridge",
+            "src": "contracts/src/AuroraErc20FastBridge.sol:58"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(IERC20)5411": {
+            "label": "contract IERC20",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IEvmErc20)8476": {
+            "label": "contract IEvmErc20",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint128)": {
+            "label": "mapping(address => uint128)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)1837_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_string_memory_ptr,t_mapping(t_address,t_uint128))": {
+            "label": "mapping(string => mapping(address => uint128))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_string_memory_ptr,t_struct(TokenInfo)6731_storage)": {
+            "label": "mapping(string => struct TokenInfo)",
+            "numberOfBytes": "32"
+          },
+          "t_string_memory_ptr": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(NEAR)29_storage": {
+            "label": "struct NEAR",
+            "members": [
+              {
+                "label": "initialized",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "wNEAR",
+                "type": "t_contract(IERC20)5411",
+                "offset": 1,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)1837_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(TokenInfo)6731_storage": {
+            "label": "struct TokenInfo",
+            "members": [
+              {
+                "label": "auroraTokenAddress",
+                "type": "t_contract(IEvmErc20)8476",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "isStorageRegistered",
+                "type": "t_bool",
+                "offset": 20,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint128": {
+            "label": "uint128",
+            "numberOfBytes": "16"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/aurora/.openzeppelin/unknown-1313161555.json
+++ b/aurora/.openzeppelin/unknown-1313161555.json
@@ -1913,6 +1913,284 @@
           }
         }
       }
+    },
+    "44406ff7c6dd3a6cc1c7240057ea8a804cdf699d65f0bca1be3ca5d878e0f286": {
+      "address": "0x713959c08d426B87c8435bf68775D21483B37c90",
+      "txHash": "0xb01a50d404f5103196e89395a6f9df66cdb4cc576e6c6cd27ebfa19c7c375e29",
+      "layout": {
+        "solcVersion": "0.8.17",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC1967UpgradeUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:169"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:111"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)1837_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:62"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:260"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "near",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_struct(NEAR)29_storage",
+            "contract": "AuroraErc20FastBridge",
+            "src": "contracts/src/AuroraErc20FastBridge.sol:43"
+          },
+          {
+            "label": "fastBridgeAccountIdOnNear",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_string_storage",
+            "contract": "AuroraErc20FastBridge",
+            "src": "contracts/src/AuroraErc20FastBridge.sol:44"
+          },
+          {
+            "label": "auroraEngineAccountIdOnNear",
+            "offset": 0,
+            "slot": "303",
+            "type": "t_string_storage",
+            "contract": "AuroraErc20FastBridge",
+            "src": "contracts/src/AuroraErc20FastBridge.sol:45"
+          },
+          {
+            "label": "isWhitelistModeEnabled",
+            "offset": 0,
+            "slot": "304",
+            "type": "t_bool",
+            "contract": "AuroraErc20FastBridge",
+            "src": "contracts/src/AuroraErc20FastBridge.sol:46"
+          },
+          {
+            "label": "whitelistedUsers",
+            "offset": 0,
+            "slot": "305",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "AuroraErc20FastBridge",
+            "src": "contracts/src/AuroraErc20FastBridge.sol:49"
+          },
+          {
+            "label": "registeredTokens",
+            "offset": 0,
+            "slot": "306",
+            "type": "t_mapping(t_string_memory_ptr,t_struct(TokenInfo)6731_storage)",
+            "contract": "AuroraErc20FastBridge",
+            "src": "contracts/src/AuroraErc20FastBridge.sol:53"
+          },
+          {
+            "label": "balance",
+            "offset": 0,
+            "slot": "307",
+            "type": "t_mapping(t_string_memory_ptr,t_mapping(t_address,t_uint128))",
+            "contract": "AuroraErc20FastBridge",
+            "src": "contracts/src/AuroraErc20FastBridge.sol:57"
+          },
+          {
+            "label": "nativeTokenAccountIdOnNear",
+            "offset": 0,
+            "slot": "308",
+            "type": "t_string_storage",
+            "contract": "AuroraErc20FastBridge",
+            "src": "contracts/src/AuroraErc20FastBridge.sol:58"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(IERC20)5411": {
+            "label": "contract IERC20",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IEvmErc20)8476": {
+            "label": "contract IEvmErc20",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint128)": {
+            "label": "mapping(address => uint128)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)1837_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_string_memory_ptr,t_mapping(t_address,t_uint128))": {
+            "label": "mapping(string => mapping(address => uint128))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_string_memory_ptr,t_struct(TokenInfo)6731_storage)": {
+            "label": "mapping(string => struct TokenInfo)",
+            "numberOfBytes": "32"
+          },
+          "t_string_memory_ptr": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(NEAR)29_storage": {
+            "label": "struct NEAR",
+            "members": [
+              {
+                "label": "initialized",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "wNEAR",
+                "type": "t_contract(IERC20)5411",
+                "offset": 1,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)1837_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(TokenInfo)6731_storage": {
+            "label": "struct TokenInfo",
+            "members": [
+              {
+                "label": "auroraTokenAddress",
+                "type": "t_contract(IEvmErc20)8476",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "isStorageRegistered",
+                "type": "t_bool",
+                "offset": 20,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint128": {
+            "label": "uint128",
+            "numberOfBytes": "16"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/aurora/contracts/src/AuroraErc20FastBridge.sol
+++ b/aurora/contracts/src/AuroraErc20FastBridge.sol
@@ -532,6 +532,22 @@ contract AuroraErc20FastBridge is Initializable, UUPSUpgradeable, AccessControlU
     }
 
     /**
+     * @dev Increases the user's balance by the admin to be able to withdraw stuck tokens if the XCC fails at some point.
+     * @param token The token NEAR account id.
+     * @param recipient The address of the recipient.
+     * @param amount The amount of tokens to increase the balance.
+     * Requirements:
+     * - The caller must have the `DEFAULT_ADMIN_ROLE`.
+     */
+    function forceIncreaseBalance(
+        string calldata token,
+        address recipient,
+        uint128 amount
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        balance[token][recipient] += amount;
+    }
+
+    /**
      * @dev Initiates the withdrawal of tokens from the implicit NEAR account of this fast bridge contract to the signer on the Aurora blockchain.
      * @param token The token NEAR account id to be withdrawn.
      * @param recipient The address of the recipient. His tokens will be transferred from fast-bridge contract to him.

--- a/aurora/hardhat.config.js
+++ b/aurora/hardhat.config.js
@@ -245,13 +245,30 @@ task("set-native-token-account-id", "Set the native token account id")
     await setNativeTokenAccountId(signer, config, taskArgs.fastBridgeAddress);
   });
 
+
+task('force_increase_balance', 'Force increase users balance')
+.addParam("auroraFastBridgeConfigName", "File name without extension for the config " +
+    "with dependencies' accounts and addresses used in Aurora Fast Bridge. " +
+    "If the CONFIG_NAME is provided, the config with path ./configs/CONFIG_NAME.json will be used.")
+.addParam('fastBridgeAddress', 'Aurora Fast Bridge address')
+.addParam('token', "Token account id on Near")
+.addParam('recipient', "Recipient address on Aurora")
+.addParam('amount', "Withdraw tokens amount")
+.setAction(async taskArgs => {
+    const { forceIncreaseBalance } = require('./scripts/utils');
+    const [signer] = await hre.ethers.getSigners();
+
+    const config = require(`./configs/${taskArgs.auroraFastBridgeConfigName}.json`);
+    await forceIncreaseBalance(signer, config, taskArgs.fastBridgeAddress, taskArgs.token, taskArgs.recipient, taskArgs.amount);
+});
+
 module.exports = {
     solidity: {
         version: "0.8.17",
         settings: {
             optimizer: {
                 enabled: true,
-                runs: 200
+                runs: 75
             },
             metadata: {
                 // do not include the metadata hash, since this is machine dependent

--- a/aurora/hardhat.config.js
+++ b/aurora/hardhat.config.js
@@ -138,7 +138,7 @@ task('withdraw_from_implicit_near_account', 'Withdraw tokens to user from Aurora
         const [signer] = await hre.ethers.getSigners();
         const config = require(`./configs/${taskArgs.auroraFastBridgeConfigName}.json`);
 
-        if (recipientAddress != "") {
+        if (taskArgs.recipientAddress != "") {
             await withdraw_from_implicit_near_account(signer, config, taskArgs.fastBridgeAddress, taskArgs.nearTokenAccountId, taskArgs.recipientAddress);
         } else {
             await withdraw_from_implicit_near_account(signer, config, taskArgs.fastBridgeAddress, taskArgs.nearTokenAccountId, signer.address);

--- a/aurora/integration-tests/Cargo.lock
+++ b/aurora/integration-tests/Cargo.lock
@@ -375,7 +375,7 @@ dependencies = [
 [[package]]
 name = "aurora-sdk-integration-tests"
 version = "0.1.1"
-source = "git+https://github.com/aurora-is-near/aurora-contracts-sdk.git?rev=8f13bb44059c0be284446861222d4e6787c3bb05#8f13bb44059c0be284446861222d4e6787c3bb05"
+source = "git+https://github.com/aurora-is-near/aurora-contracts-sdk.git#089ba61333d063d68185f27dd2512dc968108523"
 dependencies = [
  "anyhow",
  "aurora-engine 2.9.0",

--- a/aurora/integration-tests/Cargo.lock
+++ b/aurora/integration-tests/Cargo.lock
@@ -374,8 +374,8 @@ dependencies = [
 
 [[package]]
 name = "aurora-sdk-integration-tests"
-version = "0.1.0"
-source = "git+https://github.com/aurora-is-near/aurora-contracts-sdk.git#176caccd008066b7a7754d3abf09d75aaaedaa02"
+version = "0.1.1"
+source = "git+https://github.com/aurora-is-near/aurora-contracts-sdk.git?rev=8f13bb44059c0be284446861222d4e6787c3bb05#8f13bb44059c0be284446861222d4e6787c3bb05"
 dependencies = [
  "anyhow",
  "aurora-engine 2.9.0",

--- a/aurora/integration-tests/Cargo.toml
+++ b/aurora/integration-tests/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aurora-sdk-integration-tests = { git = "https://github.com/aurora-is-near/aurora-contracts-sdk.git", rev = "8f13bb44059c0be284446861222d4e6787c3bb05" }
+aurora-sdk-integration-tests = { git = "https://github.com/aurora-is-near/aurora-contracts-sdk.git" }
 fast-bridge-common = { git = "https://github.com/aurora-is-near/fast-bridge-common.git", tag = "0.2.1" }
 fastbridge = { path = "../../near/contracts/bridge" }
 serde = {version = "1", features = ["derive"] }

--- a/aurora/integration-tests/Cargo.toml
+++ b/aurora/integration-tests/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aurora-sdk-integration-tests = { git = "https://github.com/aurora-is-near/aurora-contracts-sdk.git" }
+aurora-sdk-integration-tests = { git = "https://github.com/aurora-is-near/aurora-contracts-sdk.git", rev = "8f13bb44059c0be284446861222d4e6787c3bb05" }
 fast-bridge-common = { git = "https://github.com/aurora-is-near/fast-bridge-common.git", tag = "0.2.1" }
 fastbridge = { path = "../../near/contracts/bridge" }
 serde = {version = "1", features = ["derive"] }

--- a/aurora/integration-tests/src/aurora_fast_bridge_wrapper.rs
+++ b/aurora/integration-tests/src/aurora_fast_bridge_wrapper.rs
@@ -679,7 +679,7 @@ pub mod aurora_fast_bridge_wrapper {
                 .await
                 .unwrap();
 
-        let constructor = forge::forge_build(
+        let constructor = forge::forge_build_with_args(
             contract_path,
             &[
                 format!(
@@ -696,6 +696,7 @@ pub mod aurora_fast_bridge_wrapper {
                 "AuroraErc20FastBridge.sol",
                 "AuroraErc20FastBridge.json",
             ],
+            &["--optimize", "--optimizer-runs", "75"],
         )
         .await
         .unwrap();

--- a/aurora/scripts/utils.js
+++ b/aurora/scripts/utils.js
@@ -161,6 +161,13 @@ async function setNativeTokenAccountId(signer, config, fastBridgeAddress) {
   console.log("Transaction hash: ", receipt.hash);
 }
 
+async function forceIncreaseBalance(signer, config, fastBridgeAddress, token, recipient, amount) {
+  const fastBridge = await getFastBridgeContract(signer, config, fastBridgeAddress);
+  let tx = await fastBridge.forceIncreaseBalance(token, recipient, amount);
+  let receipt = await tx.wait();
+  console.log("Transaction hash: ", receipt.hash);
+}
+
 exports.get_token_aurora_address = get_token_aurora_address;
 exports.get_implicit_near_account_id = get_implicit_near_account_id;
 exports.set_whitelist_mode_for_users = set_whitelist_mode_for_users;
@@ -174,3 +181,4 @@ exports.withdraw_from_implicit_near_account = withdraw_from_implicit_near_accoun
 exports.get_balance = get_balance;
 exports.deploySDK = deploySDK;
 exports.setNativeTokenAccountId = setNativeTokenAccountId;
+exports.forceIncreaseBalance = forceIncreaseBalance;


### PR DESCRIPTION
The current XCC implementation is subjected to a race condition.
Here is an example: https://nearblocks.io/txns/3wMoZW7Y75Y7Fv3fh5iGZiphgskms9DYnwHnw6YDttbT#execution

This PR
* Adds an extra admin API to be able to withdraw the stuck tokens by the admin.
* Decrease the optimizer runs to reduce the contract size